### PR TITLE
[PR] #181 시각 이미지 기반 객체 좌표 산출 연구

### DIFF
--- a/research/VDRS/archive/visual_img_position.py/cal_degree.py
+++ b/research/VDRS/archive/visual_img_position.py/cal_degree.py
@@ -1,0 +1,79 @@
+# 1인칭 화면에서 적 전차 픽셀 값과 아군 전차 위치, 터렛 각도 입력값 넣으면 포신과의 적과의 각도 알려줄 수 있도록 
+
+import csv
+
+def calculate_relative_angles(x_pixel, y_pixel, screen_w, screen_h, fov_h, fov_v):
+    """
+    1인칭 화면 픽셀 좌표 -> 포신 기준 수평/수직 상대각도
+    """
+    # 화면 중심
+    cx = screen_w / 2
+    cy = screen_h / 2
+
+    # 수평 각도 계산 (왼쪽 음수, 오른쪽 양수)
+    rel_angle_h = ((x_pixel - cx) / cx) * (fov_h / 2)
+
+    # 수직 각도 계산 (위쪽 양수, 아래쪽 음수)
+    rel_angle_v = ((cy - y_pixel) / cy) * (fov_v / 2)
+
+    # 방향 판별 (수평 기준)
+    if rel_angle_h > 0:
+        direction = "오른쪽"
+    elif rel_angle_h < 0:
+        direction = "왼쪽"
+    else:
+        direction = "정면"
+
+    return rel_angle_h, rel_angle_v, direction
+
+def save_angles_to_csv(results, output_csv):
+    fieldnames = ['frame','x_pixel','y_pixel','rel_angle_h','rel_angle_v','direction']
+    with open(output_csv, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+    print(f"✅ CSV 저장 완료: {output_csv}")
+
+# 🔹 사용자 입력 영역
+if __name__ == "__main__":
+    # -------------------------------
+    # 화면 정보 입력
+    screen_w = 1920         # 화면 가로 해상도(픽셀)
+    screen_h = 1080         # 화면 세로 해상도(픽셀)
+    fov_h = 47.81061        # 화면 수평 시야각(FOV, degrees)
+    fov_v = 28.0            # 화면 수직 시야각(FOV, degrees)
+    # -------------------------------
+
+    # -------------------------------
+    # 프레임별 적 전차 픽셀 좌표 입력
+    # x_pixel, y_pixel = 1인칭 화면에서 적 전차 중심 픽셀 좌표
+    # frame = 각 프레임 이름/번호 (임의로 지정)
+    frames = [
+        {'frame':'frame001','x_pixel':1606,'y_pixel':540}
+    ]
+    # -------------------------------
+
+    results = []
+    for f in frames:
+        rel_h, rel_v, direction = calculate_relative_angles(
+            f['x_pixel'], f['y_pixel'], screen_w, screen_h, fov_h, fov_v
+        )
+        results.append({
+            'frame': f['frame'],
+            'x_pixel': f['x_pixel'],
+            'y_pixel': f['y_pixel'],
+            'rel_angle_h': rel_h,
+            'rel_angle_v': rel_v,
+            'direction': direction
+        })
+
+    # -------------------------------
+    # CSV 저장 경로 입력
+    output_csv = r"C:\PYSOU\final_project\relative_angles.csv"
+    # -------------------------------
+    save_angles_to_csv(results, output_csv)
+
+    # 확인용 출력
+    for r in results:
+        print(r)

--- a/research/VDRS/archive/visual_img_position.py/cal_position.py
+++ b/research/VDRS/archive/visual_img_position.py/cal_position.py
@@ -1,0 +1,113 @@
+# 1인칭 화면에서 적 전차의 픽셀좌표와 아군전차의 위치, 터렛 각도 등 입력 시 적 전차 위치 나올 수 있도록 
+
+import math
+import csv
+
+# 1m당 맵 좌표 단위 (300/28)
+MAP_SCALE = 10.7143
+
+# -------------------------------
+# 1인칭 화면 픽셀 → 포신 기준 상대각 계산
+def calculate_relative_angles(x_pixel, y_pixel, screen_w, screen_h, fov_h, fov_v):
+    cx = screen_w / 2
+    cy = screen_h / 2
+
+    # 수평 상대각
+    rel_angle_h = ((x_pixel - cx) / cx) * (fov_h / 2)
+
+    # 수직 상대각 (선택, 높낮이 참고용)
+    rel_angle_v = ((cy - y_pixel) / cy) * (fov_v / 2)
+
+    # 수평 방향 판별
+    if rel_angle_h > 0:
+        direction = "오른쪽"
+    elif rel_angle_h < 0:
+        direction = "왼쪽"
+    else:
+        direction = "정면"
+
+    return rel_angle_h, rel_angle_v, direction
+
+# -------------------------------
+# 아군 위치, 거리, 포탑 각도, 포신 상대각 → 적 전차 절대 좌표
+def calculate_absolute_position(friendly_pos, distance_m, turret_angle_deg, rel_angle_h):
+    distance = (distance_m * MAP_SCALE) / 10  # 거리 변환
+
+    abs_angle_deg = (turret_angle_deg + rel_angle_h) % 360
+    rad = math.radians(abs_angle_deg)
+
+    x_enemy = friendly_pos[0] + distance * math.sin(rad)
+    y_enemy = friendly_pos[1] + distance * math.cos(rad)
+
+    return x_enemy, y_enemy, abs_angle_deg
+
+# -------------------------------
+# 프레임별 처리
+def process_frames(frames, screen_w, screen_h, fov_h, fov_v, friendly_pos, turret_angle_deg):
+    results = []
+    for f in frames:
+        # 1️⃣ 픽셀 → 상대각
+        rel_h, rel_v, direction = calculate_relative_angles(
+            f['x_pixel'], f['y_pixel'], screen_w, screen_h, fov_h, fov_v
+        )
+        # 2️⃣ 절대 좌표 계산
+        x_enemy, y_enemy, abs_angle = calculate_absolute_position(
+            friendly_pos, f['distance_m'], turret_angle_deg, rel_h
+        )
+        # 3️⃣ 결과 저장
+        results.append({
+            'frame': f['frame'],
+            'x_pixel': f['x_pixel'],
+            'y_pixel': f['y_pixel'],
+            'rel_angle_h': rel_h,
+            'rel_angle_v': rel_v,
+            'direction': direction,
+            'distance_m': f['distance_m'],
+            'x_enemy': x_enemy,
+            'y_enemy': y_enemy,
+            'abs_angle': abs_angle
+        })
+    return results
+
+# -------------------------------
+# CSV 저장
+def save_results_to_csv(results, output_csv):
+    fieldnames = ['frame','x_pixel','y_pixel','rel_angle_h','rel_angle_v','direction','distance_m','x_enemy','y_enemy','abs_angle']
+    with open(output_csv, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+    print(f"✅ CSV 저장 완료: {output_csv}")
+
+# -------------------------------
+# 🔹 사용자 입력 영역
+if __name__ == "__main__":
+    # 1️⃣ 화면 정보
+    screen_w = 1919          # 화면 가로 해상도
+    screen_h = 1047          # 화면 세로 해상도
+    fov_h = 47.81061         # 수평 시야각
+    fov_v = 28.0             # 수직 시야각
+
+    # 2️⃣ 아군 전차 위치 (맵 좌표) 및 포탑 각도
+    friendly_pos = (0, 0)  # 아군 전차 좌표
+    turret_angle_deg = 45.12          # 포탑 절대각, 0 = 북쪽
+
+    # 3️⃣ 프레임별 입력
+    # x_pixel, y_pixel: 1인칭 화면에서 적 전차 중심 픽셀
+    # distance_m: 아군 전차와 적 전차 사이 거리(m)
+    frames = [
+        {'frame':'frame001','x_pixel':957,'y_pixel':536,'distance_m':390.0}
+    ]
+
+    # 4️⃣ CSV 저장 경로
+    output_csv = r"C:\PYSOU\final_project\enemy_positions_map.csv"
+
+    # -------------------------------
+    # 처리
+    results = process_frames(frames, screen_w, screen_h, fov_h, fov_v, friendly_pos, turret_angle_deg)
+    save_results_to_csv(results, output_csv)
+
+    # 확인용 출력
+    for r in results:
+        print(r)


### PR DESCRIPTION
## 시각 이미지 기반 객체 좌표 산출 연구

### 전차 시점 기반 적 전차 좌표 계산기 (Tank Target Coordinate Calculator)

이 코드는 1인칭 전차 시점의 픽셀 좌표, 포탑 각도, 거리(m) 정보를 기반으로  
적 전차의 맵 절대 좌표를 자동 계산하는 Python 스크립트입니다.

---

### 주요 기능

| 기능 | 설명 |
|------|------|
| 화면 픽셀 → 상대각 계산 | 시야 중심으로부터 적 전차의 픽셀 위치를 이용해 좌우/상하 상대각을 구함 |
| 상대각 + 포탑 각도 → 절대 좌표 변환 | 실제 맵에서 적 전차의 절대 좌표를 계산 |
| 결과 자동 CSV 저장 | 계산 결과를 CSV 파일로 내보내기 |
| 단위 자동 변환 | 거리(m) → 맵 단위(1m = 10.7143) 자동 변환 및 스케일 보정 |

---

### 계산 과정 요약

1. 화면 좌표 → 상대각 변환
   ```python
   rel_angle_h = ((x_pixel - cx) / cx) * (fov_h / 2)
   rel_angle_v = ((cy - y_pixel) / cy) * (fov_v / 2)

2. 상대각 + 포탑 절대각 → 적 전차 방향 각
abs_angle_deg = (turret_angle_deg + rel_angle_h) % 360

3. 거리 및 방향 → 맵 절대 좌표 변환
4. distance = (distance_m * MAP_SCALE) / 10  # 1m → 맵 단위
x_enemy = friendly_pos[0] + distance * math.sin(rad)
y_enemy = friendly_pos[1] + distance * math.cos(rad)

4. 결과를 CSV 파일로 저장
CSV 저장 완료: C:\PYSOU\final_project\enemy_positions_map.csv


### 변수명 

screen_w, screen_h = 게임 또는 시야 해상도  ex) 1919 × 1047
fov_h, fov_v = 수평/수직 시야각 (도 단위)  ex) 47.81 / 28.0
friendly_pos = 아군 전차의 맵 좌표  ex) (60, 60)
turret_angle_deg = 포탑의 절대 회전 각도 (0° = 북쪽)  ex) 0.0
frames = 프레임별 데이터 목록  ex) 픽셀좌표 + 거리
distance_m = 아군과 적 전차 사이 거리 (m)  ex) 110.0


close #181 