### PR TITLE
[PR] #153 리스트로 나오는 카드 스크롤 설정

### DIFF
--- a/frontend/TCIS/src/layouts/MainLayout.vue
+++ b/frontend/TCIS/src/layouts/MainLayout.vue
@@ -40,9 +40,9 @@ const getFlexStyle = (ratio: number) => ({
 
 </script>
 <template>
-    <div class="flex">
+    <div class="flex h-full">
         <!-- 좌측 사이드바 -->
-        <div :style="getFlexStyle(layoutConfig.leftSidebar)" class="bg-white">
+        <div :style="getFlexStyle(layoutConfig.leftSidebar)" class="bg-white min-h-0">
             <SideBar 
                 class="h-full" 
                 :contents="leftSideBar.contents" 
@@ -51,12 +51,12 @@ const getFlexStyle = (ratio: number) => ({
         </div>
         
         <!-- 맵 영역 -->
-        <div :style="getFlexStyle(layoutConfig.map)">
+        <div :style="getFlexStyle(layoutConfig.map)" class="min-h-0">
             <BattlefieldMap class="h-full" />
         </div>
         
         <!-- 우측 사이드바 -->
-        <div :style="getFlexStyle(layoutConfig.rightSidebar)" class="bg-white">
+        <div :style="getFlexStyle(layoutConfig.rightSidebar)" class="bg-white min-h-0">
             <SideBar 
                 class="h-full" 
                 :contents="rightSideBar.contents" 

--- a/frontend/TCIS/src/layouts/SideBar.vue
+++ b/frontend/TCIS/src/layouts/SideBar.vue
@@ -47,7 +47,7 @@ const getFlexStyle = (ratio: number) => {
             v-for="(componentName, index) in contents"
             :key="componentName"
             :style="getFlexStyle(col[index])"
-            class="flex-item"
+            class="flex-item min-h-0"
         >
             <component
                 :is="getComponent(componentName)"


### PR DESCRIPTION
##  리스트로 나오는 카드 스크롤 설정
최상단 MainLayout.vue에서 높이 설정이 되어있지 않아 자동으로 높이가 Auto로 설정되어 생긴현상
높이 및 최소높이 설정으로 수정완료

closes #153 