### PR TITLE
[PR] #240 거리인식 방법 변경으로 인한 시나리오에 따른 UI변경

### DIFF
--- a/frontend/TCIS/src/components/icons/EnemyAroundIcon.vue
+++ b/frontend/TCIS/src/components/icons/EnemyAroundIcon.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+interface Props {
+  x: number
+  y: number
+  size?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 10
+})
+
+// 원본 SVG는 48x48, 중심이 24,24
+// size 10을 기준으로 스케일 조정
+const scale = props.size / 10
+const backgroundRadius = 24 * scale / 2.4  // 배경 원을 적절히 축소
+const color = '#FF0000'
+
+// 원본 SVG의 중심이 (24, 24)이므로, props.x, props.y를 중심으로 재배치
+</script>
+
+<template>
+  <g>
+    <!-- 배경 원 (투명도) -->
+    <circle
+      :cx="props.x"
+      :cy="props.y"
+      :r="backgroundRadius"
+      :fill="color"
+      fill-opacity="0.15"
+    />
+    
+    <!-- 회전된 사각형 (다이아몬드) - 원본 SVG: x=16.7071, y=25.5, center=(24,24) -->
+    <rect
+      :x="(props.x - (24 - 16.7071) * scale / 2.4)"
+      :y="(props.y + (25.5 - 24) * scale / 2.4)"
+      :width="11.0208 * scale / 2.4"
+      :height="11.0208 * scale / 2.4"
+      rx="0.5"
+      :transform="`rotate(-45 ${props.x - (24 - 16.7071) * scale / 2.4} ${props.y + (25.5 - 24) * scale / 2.4})`"
+      :stroke="color"
+      fill="none"
+      :stroke-width="1 * scale / 2.4"
+    />
+    
+    <!-- 타원 - 원본 SVG: 중심이 약 (24.5, 25.5) -> 중앙(24)으로 조정 -->
+    <path
+      :d="`M ${props.x + 0.5 * scale / 2.4} ${props.y - 0.5 * scale / 2.4} 
+           C ${props.x + 1.5259 * scale / 2.4} ${props.y - 0.5 * scale / 2.4} ${props.x + 2.4309 * scale / 2.4} ${props.y - 0.2391 * scale / 2.4} ${props.x + 3.0635 * scale / 2.4} ${props.y + 0.1562 * scale / 2.4} 
+           C ${props.x + 3.7031 * scale / 2.4} ${props.y + 0.556 * scale / 2.4} ${props.x + 4 * scale / 2.4} ${props.y + 1.0443 * scale / 2.4} ${props.x + 4 * scale / 2.4} ${props.y + 1.5 * scale / 2.4} 
+           C ${props.x + 4 * scale / 2.4} ${props.y + 1.9557 * scale / 2.4} ${props.x + 3.7031 * scale / 2.4} ${props.y + 2.444 * scale / 2.4} ${props.x + 3.0635 * scale / 2.4} ${props.y + 2.8438 * scale / 2.4} 
+           C ${props.x + 2.4309 * scale / 2.4} ${props.y + 3.2391 * scale / 2.4} ${props.x + 1.5259 * scale / 2.4} ${props.y + 3.5 * scale / 2.4} ${props.x + 0.5 * scale / 2.4} ${props.y + 3.5 * scale / 2.4} 
+           C ${props.x - 0.5259 * scale / 2.4} ${props.y + 3.5 * scale / 2.4} ${props.x - 1.4309 * scale / 2.4} ${props.y + 3.2391 * scale / 2.4} ${props.x - 2.0635 * scale / 2.4} ${props.y + 2.8438 * scale / 2.4} 
+           C ${props.x - 2.7031 * scale / 2.4} ${props.y + 2.444 * scale / 2.4} ${props.x - 3 * scale / 2.4} ${props.y + 1.9557 * scale / 2.4} ${props.x - 3 * scale / 2.4} ${props.y + 1.5 * scale / 2.4} 
+           C ${props.x - 3 * scale / 2.4} ${props.y + 1.0443 * scale / 2.4} ${props.x - 2.7031 * scale / 2.4} ${props.y + 0.556 * scale / 2.4} ${props.x - 2.0635 * scale / 2.4} ${props.y + 0.1562 * scale / 2.4} 
+           C ${props.x - 1.4309 * scale / 2.4} ${props.y - 0.2391 * scale / 2.4} ${props.x - 0.5259 * scale / 2.4} ${props.y - 0.5 * scale / 2.4} ${props.x + 0.5 * scale / 2.4} ${props.y - 0.5 * scale / 2.4} Z`"
+      :stroke="color"
+      fill="none"
+      :stroke-width="1 * scale / 2.4"
+    />
+    
+    <!-- 상단 원 - 원본 SVG: cx=24.5, cy=16, center=(24,24) -->
+    <circle
+      :cx="props.x + 0.5 * scale / 2.4"
+      :cy="props.y - 8 * scale / 2.4"
+      :r="1 * scale / 2.4"
+      :fill="color"
+    />
+  </g>
+</template>

--- a/frontend/TCIS/src/components/icons/PersonAroundIcon.vue
+++ b/frontend/TCIS/src/components/icons/PersonAroundIcon.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+interface Props {
+  x: number
+  y: number
+  size?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 10
+})
+
+// 아이콘 비율 (원본 SVG 기준: 32x32)
+const scale = props.size / 10
+const backgroundRadius = 16 * scale
+const centerRadius = 4 * scale
+const color = '#FF0000'
+</script>
+
+<template>
+  <g>
+    <!-- 배경 원 (투명도) -->
+    <circle
+      :cx="props.x"
+      :cy="props.y"
+      :r="backgroundRadius"
+      :fill="color"
+      fill-opacity="0.15"
+    />
+    
+    <!-- 중심 원 -->
+    <circle
+      :cx="props.x"
+      :cy="props.y"
+      :r="centerRadius"
+      :fill="color"
+    />
+  </g>
+</template>

--- a/frontend/TCIS/src/components/map/DetectedObjects.vue
+++ b/frontend/TCIS/src/components/map/DetectedObjects.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import type { DetectedObject } from '@/types/detection'
 import EnemyIcon from '@/components/icons/EnemyIcon.vue'
+import EnemyAroundIcon from '@/components/icons/EnemyAroundIcon.vue'
 import CarIcon from '@/components/icons/CarIcon.vue'
 import PersonIcon from '@/components/icons/PersonIcon.vue'
+import PersonAroundIcon from '@/components/icons/PersonAroundIcon.vue'
 import RockIcon from '@/components/icons/RockIcon.vue'
 import MineIcon from '@/components/icons/MineIcon.vue'
 
@@ -25,9 +27,25 @@ defineProps<Props>()
       :size="20"
     />
 
+    <!-- 적 전차 (주변) -->
+    <EnemyAroundIcon 
+      v-else-if="obj.class_name === 'tank_around'"
+      :x="coordToSvg(obj.position.x, obj.position.y).x"
+      :y="coordToSvg(obj.position.x, obj.position.y).y"
+      :size="50"
+    />
+
     <!-- 적 보병 -->
     <PersonIcon 
       v-else-if="obj.class_name === 'human'"
+      :x="coordToSvg(obj.position.x, obj.position.y).x"
+      :y="coordToSvg(obj.position.x, obj.position.y).y"
+      :size="8"
+    />
+
+    <!-- 적 보병 (주변) -->
+    <PersonAroundIcon 
+      v-else-if="obj.class_name === 'human_around'"
       :x="coordToSvg(obj.position.x, obj.position.y).x"
       :y="coordToSvg(obj.position.x, obj.position.y).y"
       :size="8"

--- a/frontend/TCIS/src/components/sidebar/DetectedObjects.vue
+++ b/frontend/TCIS/src/components/sidebar/DetectedObjects.vue
@@ -43,8 +43,9 @@ const otherItems = computed(() => [
         class="flex-1"
       />
       
-      <!-- 아군 -->
+      <!-- 아군 (객체가 있을 때만 표시) -->
       <ObjectsList
+        v-if="allyCount > 0"
         title="아군"
         :count="allyCount"
         bg-color="bg-rotem-50"
@@ -55,8 +56,9 @@ const otherItems = computed(() => [
         class="flex-1"
       />
       
-      <!-- 기타 -->
+      <!-- 기타 (객체가 있을 때만 표시) -->
       <ObjectsList
+        v-if="otherCount > 0"
         title="기타"
         :count="otherCount"
         bg-color="bg-success-50"

--- a/frontend/TCIS/src/types/detection.ts
+++ b/frontend/TCIS/src/types/detection.ts
@@ -13,10 +13,12 @@ export enum ObjectClassId {
   Mine1 = 8,
   Wall2 = 9,
   Wall2X10 = 10,
+  Tank2 = 11,
+  Human2 = 12
 }
 
 //객체 클래스 이름
-export type ObjectClassName = 'tank' | 'car' | 'truck' | 'other' | 'human' | 'rock_small' | 'rock_large' | 'mine' | 'wall'
+export type ObjectClassName = 'tank' | 'tank_around' | 'car' | 'truck' | 'other' | 'human' | 'human_around' | 'rock_small' | 'rock_large' | 'mine' | 'wall'
 
 //클래스 ID → 이름 매핑
 export const CLASS_ID_TO_NAME: Record<number, ObjectClassName> = {
@@ -31,6 +33,8 @@ export const CLASS_ID_TO_NAME: Record<number, ObjectClassName> = {
   [ObjectClassId.Mine1]: 'mine',
   [ObjectClassId.Wall2]: 'wall',
   [ObjectClassId.Wall2X10]: 'wall',
+  [ObjectClassId.Tank2]: 'tank_around',
+  [ObjectClassId.Human2]: 'human_around'
 }
 
 //클래스 이름 한글
@@ -44,7 +48,9 @@ export const CLASS_NAME_KR: Record<ObjectClassName, string> = {
   rock_small: '작은 바위',
   rock_large: '큰 바위',
   mine: '지뢰',
-  wall: '벽'
+  wall: '벽',
+  tank_around: '주변 전차',
+  human_around: '주변 보병'
 }
 
 // 프론트에서 사용할 형태


### PR DESCRIPTION
## 거리인식 방법 변경으로 인한 시나리오에 따른 UI변경

### 새로운 아이콘 컴포넌트 추가
- **EnemyAroundIcon.vue** 생성
  - 적 전차 주변 표시용 아이콘
  - 투명한 빨간 배경 원 + 적전차 단대호
  - 원본 SVG (48x48) 기준으로 좌표 변환 및 스케일 조정

- **PersonAroundIcon.vue** 생성
  - 적 보병 주변 표시용 아이콘
  - 투명한 빨간 배경 원 + 중심의 빨간 원 

### 아이콘 렌더링 로직 추가
- **DetectedObjects.vue** (map) 수정
  - `EnemyAroundIcon`, `PersonAroundIcon` import 추가
  - `tank_around` 케이스 추가
  - `human_around` 케이스 추가

### 사이드바 탐지 객체 UI 개선
- **DetectedObjects.vue** (sidebar) 수정
  - 적군 객체: 항상 표시 (기본)
  - 아군 객체: `v-if="allyCount > 0"` - 객체가 있을 때만 표시
  - 기타 객체: `v-if="otherCount > 0"` - 객체가 있을 때만 표시

closes #240 